### PR TITLE
v1.5.2: Support Bug Fixed

### DIFF
--- a/api/status_handler.go
+++ b/api/status_handler.go
@@ -36,7 +36,7 @@ func getAPIStatusHandler(res http.ResponseWriter, req *http.Request) {
 		skcSuggestionDBVersion = dbVersion
 	}
 
-	status := model.APIHealth{Version: "1.5.1", Downstream: downstreamHealth}
+	status := model.APIHealth{Version: "1.5.2", Downstream: downstreamHealth}
 
 	logger.Info(fmt.Sprintf("API Status Info! SKC DB version: %s, and SKC Suggestion Engine version: %s", skcDBVersion, skcSuggestionDBVersion))
 	res.WriteHeader(http.StatusOK)

--- a/db/skc_api_db.go
+++ b/db/skc_api_db.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
 	"log/slog"
 	"net/http"
 	"regexp"
@@ -37,7 +36,7 @@ const (
 
 func convertToFullText(subject string) string {
 	fullTextSubject := spaceRegex.ReplaceAllString(strings.ReplaceAll(subject, "-", " "), " +")
-	return fmt.Sprintf("+%s", fullTextSubject)
+	return fmt.Sprintf(`"+%s"`, fullTextSubject) // match phrase, not all words in text will match only consecutive matches of words in phrase
 }
 
 func buildVariableQuerySubjects(subjects []string) ([]interface{}, int) {
@@ -247,7 +246,6 @@ func (imp SKCDAOImplementation) GetOccurrenceOfCardNameInAllCardEffect(ctx conte
 	logger := util.LoggerFromContext(ctx)
 	logger.Info(fmt.Sprintf("Retrieving card data from DB for all cards that reference card %s in their text", cardName))
 
-	log.Println(convertToFullText(cardName))
 	if rows, err := skcDBConn.Query(findRelatedCardsUsingCardEffect, convertToFullText(cardName), cardId); err != nil {
 		return nil, handleQueryError(logger, err)
 	} else {

--- a/model/card.go
+++ b/model/card.go
@@ -29,7 +29,7 @@ func (card Card) GetPotentialMaterialsAsString() string {
 	}
 
 	color := strings.ToUpper(card.CardColor)
-	if strings.Contains(color, "PENDULUM") && color != "PENDULUM-EFFECT" {
+	if strings.Contains(color, "PENDULUM") && color != "PENDULUM-EFFECT" && color != "PENDULUM-NORMAL" {
 		effectTokens = strings.SplitAfter(strings.SplitAfter(card.CardEffect, "\n\nMonster Effect\n")[1], "\n")
 	} else {
 		effectTokens = strings.SplitAfter(card.CardEffect, "\n")


### PR DESCRIPTION
## Changes
* Fixed two bugs that can occur when fetching support for a particular card
  * Bug was caused due to how cards are being fetched from DB. The full text query was too broad. Instead of using the full card name in the query, it looked for each occurrence of each word of the card name. This fetched more cards than needed. Support output was not effected as there is still a catch in the code but it lead to the second bug
  * When determining support, if the card type is pendulum normal it would cause null pointer exception due missing catch in condition.
  * The reason the second bug was found is because the sql query was too broad and in for some cases normal pendulum monsters would be returned from DB when they shouldn't be