### PR TITLE
v1.5.5: Updated HTTPs Server To Send CA Bundle Info

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -107,7 +107,7 @@ func commonResponseMiddleware(next http.Handler) http.Handler {
 // Configures routes and their middle wares
 // This method should be called before the environment is set up as the API Key will be set according to the value found in environment
 func RunHttpServer() {
-	configureEnv()
+	serverAPIKey = util.EnvMap["API_KEY"] // configure API Key
 	router := mux.NewRouter()
 
 	// configure non-admin routes
@@ -136,7 +136,7 @@ func RunHttpServer() {
 
 	// Cors
 	corsOpts := cors.New(cors.Options{
-		AllowedOrigins: []string{"http://localhost:3000", "http://dev.thesupremekingscastle.com", "https://dev.thesupremekingscastle.com", "https://thesupremekingscastle.com", "https://www.thesupremekingscastle.com"},
+		AllowedOrigins: []string{"http://localhost:3000", "https://dev.thesupremekingscastle.com", "https://thesupremekingscastle.com", "https://www.thesupremekingscastle.com"},
 		AllowedMethods: []string{
 			http.MethodGet,
 			http.MethodPost,
@@ -149,26 +149,25 @@ func RunHttpServer() {
 		},
 	})
 
-	go serveTLS(router, corsOpts)
-	serveUnsecured(router, corsOpts)
+	serveTLS(router, corsOpts)
 }
 
-// configure server to handle HTTPS (secured) calls
+// Configures and starts an HTTPS server with TLS encryption.
+// It combines the TLS certificate and CA bundle, and utilizes the private key.
+// Finally, it applies CORS middleware.
 func serveTLS(router *mux.Router, corsOpts *cors.Cors) {
 	slog.Debug("Starting server in port 9000 (secured)")
-	if err := http.ListenAndServeTLS(":9000", "certs/certificate.crt", "certs/private.key", corsOpts.Handler(router)); err != nil { // docker does not like localhost:9000 so im just using port number
-		log.Fatalf("There was an error starting api server: %s", err)
-	}
-}
 
-// configure server to handle HTTPs (un-secured) calls
-func serveUnsecured(router *mux.Router, corsOpts *cors.Cors) {
-	slog.Debug("Starting server in port 90 (unsecured)")
-	if err := http.ListenAndServe(":90", corsOpts.Handler(router)); err != nil {
-		log.Fatalf("There was an error starting api server: %s", err)
+	combinedFile := "certs/concatenated.crt"
+	if certData, err := os.ReadFile("certs/certificate.crt"); err != nil {
+		log.Fatalf("Failed to read certificate file: %s", err)
+	} else if caBundleData, err := os.ReadFile("certs/ca_bundle.crt"); err != nil {
+		log.Fatalf("Failed to read CA bundle file: %s", err)
+	} else {
+		if err = os.WriteFile(combinedFile, append(certData, caBundleData...), 0600); err != nil {
+			log.Fatalf("Failed to write combined certificate file: %s", err)
+		} else if err := http.ListenAndServeTLS(":9000", combinedFile, "certs/private.key", corsOpts.Handler(router)); err != nil {
+			log.Fatalf("There was an error starting api server: %s", err)
+		}
 	}
-}
-
-func configureEnv() {
-	serverAPIKey = util.EnvMap["API_KEY"] // configure API Key
 }

--- a/api/status_handler.go
+++ b/api/status_handler.go
@@ -36,7 +36,7 @@ func getAPIStatusHandler(res http.ResponseWriter, req *http.Request) {
 		skcSuggestionDBVersion = dbVersion
 	}
 
-	status := model.APIHealth{Version: "1.5.4-1", Downstream: downstreamHealth}
+	status := model.APIHealth{Version: "1.5.5", Downstream: downstreamHealth}
 
 	logger.Info(fmt.Sprintf("API Status Info! SKC DB version: %s, and SKC Suggestion Engine version: %s", skcDBVersion, skcSuggestionDBVersion))
 	res.WriteHeader(http.StatusOK)

--- a/api/status_handler.go
+++ b/api/status_handler.go
@@ -36,7 +36,7 @@ func getAPIStatusHandler(res http.ResponseWriter, req *http.Request) {
 		skcSuggestionDBVersion = dbVersion
 	}
 
-	status := model.APIHealth{Version: "1.5.4", Downstream: downstreamHealth}
+	status := model.APIHealth{Version: "1.5.4-1", Downstream: downstreamHealth}
 
 	logger.Info(fmt.Sprintf("API Status Info! SKC DB version: %s, and SKC Suggestion Engine version: %s", skcDBVersion, skcSuggestionDBVersion))
 	res.WriteHeader(http.StatusOK)

--- a/db/connect.go
+++ b/db/connect.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	minPoolSize = 30
-	maxPoolSize = 50
+	minPoolSize = 20
+	maxPoolSize = 30
 )
 
 // Connect to SKC database.

--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -17,12 +17,12 @@ services:
         limits:
           memory: 75m
     networks:
-      - skc-network
+      - skc
     environment:
       - SKC_SUGGESTION_ENGINE_DOT_ENV_FILE=.env_docker_local
 
 networks:
-  skc-network:
-    name: skc-network
+  skc:
+    name: skc
     driver: bridge
-    external: true
+    external: true # network was alredy created, if you need to recreate the network - make this false

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
         limits:
           memory: 75m
     networks:
-      - skc-network
+      - skc
     environment:
       - SKC_SUGGESTION_ENGINE_DOT_ENV_FILE=.env_prod
     labels:
@@ -37,7 +37,7 @@ services:
       com.datadoghq.tags.service: "skc-suggestion-engine"
 
 networks:
-  skc-network:
-    name: skc-network
+  skc:
+    name: skc
     driver: bridge
-    external: true
+    external: true # network was alredy created, if you need to recreate the network - make this false


### PR DESCRIPTION
## Changes
* To avoid having clients add the CA Bundle in truststore, the API will include both the certificate and ca_bundle when serving TLS requests
* Removed insecure access
* Updated docker network info