### PR TITLE
v1.5.6: Improved Card of the Day Logic

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4.2.2
 
     - name: Set up Golang
       uses: actions/setup-go@v5.0.2

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -18,7 +18,7 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
 
       - name: Set up Golang
         uses: actions/setup-go@v5.0.2

--- a/api/card_of_the_day_handler.go
+++ b/api/card_of_the_day_handler.go
@@ -14,11 +14,10 @@ import (
 func getCardOfTheDay(res http.ResponseWriter, req *http.Request) {
 	logger, ctx := util.NewRequestSetup(context.Background(), "card of the day")
 
-	date := time.Now().In(chicagoLocation).Format("2006-01-02")
-	cardOfTheDay := model.CardOfTheDay{Date: date, Version: 1}
-	logger.Info(fmt.Sprintf("Fetching card of the day - todays date %s", date))
+	cardOfTheDay := model.CardOfTheDay{Date: time.Now().In(chicagoLocation).Format("2006-01-02"), Version: 1}
+	logger.Info(fmt.Sprintf("Fetching card of the day - todays date %s", cardOfTheDay.Date))
 
-	if cardID, err := skcSuggestionEngineDBInterface.GetCardOfTheDay(ctx, date); cardID == nil {
+	if cardID, err := skcSuggestionEngineDBInterface.GetCardOfTheDay(ctx, cardOfTheDay.Date, cardOfTheDay.Version); cardID == nil {
 		if err := fetchNewCardOfTheDayAndPersist(ctx, &cardOfTheDay); err != nil {
 			err.HandleServerResponse(res)
 			return

--- a/api/card_of_the_day_handler.go
+++ b/api/card_of_the_day_handler.go
@@ -26,7 +26,7 @@ func getCardOfTheDay(res http.ResponseWriter, req *http.Request) {
 	} else if err != nil {
 		err.HandleServerResponse(res)
 	} else {
-		logger.Warn(fmt.Sprintf("Existing card of the day for %s found! Card of the day: %s", date, *cardID))
+		logger.Warn(fmt.Sprintf("Existing card of the day found! COTD: %s", *cardID))
 		cardOfTheDay.CardID = *cardID
 	}
 
@@ -43,10 +43,19 @@ func getCardOfTheDay(res http.ResponseWriter, req *http.Request) {
 }
 
 func fetchNewCardOfTheDayAndPersist(ctx context.Context, cotd *model.CardOfTheDay) *model.APIError {
-	util.LoggerFromContext(ctx).Info(fmt.Sprintf("There was no card of the day found for %s, fetching random card from DB.", cotd.Date))
+	logger := util.LoggerFromContext(ctx)
+	logger.Info("There was no COTD picked for today - getting random card")
 	e := &model.APIError{StatusCode: http.StatusInternalServerError, Message: "An error occurred fetching new card of the day."}
 
-	if randomCardId, err := skcDBInterface.GetRandomCard(ctx); err != nil {
+	var err *model.APIError
+	var previousCOTDData []string
+	if previousCOTDData, err = skcSuggestionEngineDBInterface.GetHistoricalCardOfTheDayData(ctx, cotd.Version); err != nil {
+		return e
+	}
+
+	logger.Warn(fmt.Sprintf("Ignoring cards that were previously COTD, total: %d", len(previousCOTDData)))
+
+	if randomCardId, err := skcDBInterface.GetRandomCard(ctx, previousCOTDData); err != nil {
 		return e
 	} else {
 		cotd.CardID = randomCardId

--- a/api/card_of_the_day_handler.go
+++ b/api/card_of_the_day_handler.go
@@ -53,7 +53,7 @@ func fetchNewCardOfTheDayAndPersist(ctx context.Context, cotd *model.CardOfTheDa
 		return e
 	}
 
-	logger.Warn(fmt.Sprintf("Ignoring cards that were previously COTD, total: %d", len(previousCOTDData)))
+	logger.Warn(fmt.Sprintf("Ignoring cards that were previously COTD, total ignored: %d", len(previousCOTDData)))
 
 	if randomCardId, err := skcDBInterface.GetRandomCard(ctx, previousCOTDData); err != nil {
 		return e

--- a/api/status_handler.go
+++ b/api/status_handler.go
@@ -36,7 +36,7 @@ func getAPIStatusHandler(res http.ResponseWriter, req *http.Request) {
 		skcSuggestionDBVersion = dbVersion
 	}
 
-	status := model.APIHealth{Version: "1.5.5", Downstream: downstreamHealth}
+	status := model.APIHealth{Version: "1.5.6", Downstream: downstreamHealth}
 
 	logger.Info(fmt.Sprintf("API Status Info! SKC DB version: %s, and SKC Suggestion Engine version: %s", skcDBVersion, skcSuggestionDBVersion))
 	res.WriteHeader(http.StatusOK)

--- a/api/status_handler.go
+++ b/api/status_handler.go
@@ -36,7 +36,7 @@ func getAPIStatusHandler(res http.ResponseWriter, req *http.Request) {
 		skcSuggestionDBVersion = dbVersion
 	}
 
-	status := model.APIHealth{Version: "1.5.4-1", Downstream: downstreamHealth}
+	status := model.APIHealth{Version: "1.5.5", Downstream: downstreamHealth}
 
 	logger.Info(fmt.Sprintf("API Status Info! SKC DB version: %s, and SKC Suggestion Engine version: %s", skcDBVersion, skcSuggestionDBVersion))
 	res.WriteHeader(http.StatusOK)

--- a/api/traffic_analysis_handler.go
+++ b/api/traffic_analysis_handler.go
@@ -88,7 +88,7 @@ func trending(res http.ResponseWriter, req *http.Request) {
 	c1, c2 := make(chan *model.APIError), make(chan *model.APIError)
 	metricsForCurrentPeriod, metricsForLastPeriod := []model.TrafficResourceUtilizationMetric{}, []model.TrafficResourceUtilizationMetric{}
 	today := time.Now()
-	firstInterval, secondInterval := today.AddDate(0, 0, -7), today.AddDate(0, 0, -14)
+	firstInterval, secondInterval := today.AddDate(0, 0, -10), today.AddDate(0, 0, -20)
 
 	go getMetrics(ctx, r, firstInterval, today, &metricsForCurrentPeriod, c1)
 	go getMetrics(ctx, r, secondInterval, firstInterval, &metricsForLastPeriod, c2)

--- a/api/traffic_analysis_handler.go
+++ b/api/traffic_analysis_handler.go
@@ -88,10 +88,10 @@ func trending(res http.ResponseWriter, req *http.Request) {
 	c1, c2 := make(chan *model.APIError), make(chan *model.APIError)
 	metricsForCurrentPeriod, metricsForLastPeriod := []model.TrafficResourceUtilizationMetric{}, []model.TrafficResourceUtilizationMetric{}
 	today := time.Now()
-	twoWeeksFromToday, fourWeeksFromToday := today.AddDate(0, 0, -14), today.AddDate(0, 0, -28)
+	firstInterval, secondInterval := today.AddDate(0, 0, -7), today.AddDate(0, 0, -14)
 
-	go getMetrics(ctx, r, twoWeeksFromToday, today, &metricsForCurrentPeriod, c1)
-	go getMetrics(ctx, r, fourWeeksFromToday, twoWeeksFromToday, &metricsForLastPeriod, c2)
+	go getMetrics(ctx, r, firstInterval, today, &metricsForCurrentPeriod, c1)
+	go getMetrics(ctx, r, secondInterval, firstInterval, &metricsForLastPeriod, c2)
 
 	// get channel data and check for errors
 	if err1, err2 := <-c1, <-c2; err1 != nil {

--- a/db/skc_suggestion_engine_db.go
+++ b/db/skc_suggestion_engine_db.go
@@ -22,16 +22,16 @@ var (
 
 // interface
 type SKCSuggestionEngineDAO interface {
-	GetSKCSuggestionDBVersion(ctx context.Context) (string, error)
+	GetSKCSuggestionDBVersion(context.Context) (string, error)
 
-	InsertTrafficData(ctx context.Context, ta model.TrafficAnalysis) *model.APIError
-	GetTrafficData(ctx context.Context, resourceName model.ResourceName, from time.Time, to time.Time) ([]model.TrafficResourceUtilizationMetric, *model.APIError)
+	InsertTrafficData(context.Context, model.TrafficAnalysis) *model.APIError
+	GetTrafficData(context.Context, model.ResourceName, time.Time, time.Time) ([]model.TrafficResourceUtilizationMetric, *model.APIError)
 
-	IsBlackListed(ctx context.Context, blackListType string, blackListPhrase string) (bool, *model.APIError)
+	IsBlackListed(context.Context, string, string) (bool, *model.APIError)
 
-	GetCardOfTheDay(ctx context.Context, date string) (*string, *model.APIError)
+	GetCardOfTheDay(context.Context, string, int) (*string, *model.APIError)
 	GetHistoricalCardOfTheDayData(context.Context, int) ([]string, *model.APIError)
-	InsertCardOfTheDay(ctx context.Context, cotd model.CardOfTheDay) *model.APIError
+	InsertCardOfTheDay(context.Context, model.CardOfTheDay) *model.APIError
 }
 
 // impl
@@ -136,12 +136,12 @@ func (dbInterface SKCSuggestionEngineDAOImplementation) IsBlackListed(ctx contex
 	}
 }
 
-func (dbInterface SKCSuggestionEngineDAOImplementation) GetCardOfTheDay(ctx context.Context, date string) (*string, *model.APIError) {
+func (dbInterface SKCSuggestionEngineDAOImplementation) GetCardOfTheDay(ctx context.Context, date string, version int) (*string, *model.APIError) {
 	logger := util.LoggerFromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
-	query := bson.M{"date": date, "version": 1}
+	query := bson.M{"date": date, "version": version}
 	opts := options.FindOne().SetProjection( // select only these fields from collection
 		bson.D{
 			{Key: "cardID", Value: 1},

--- a/db/skc_suggestion_engine_db.go
+++ b/db/skc_suggestion_engine_db.go
@@ -106,12 +106,12 @@ func (dbInterface SKCSuggestionEngineDAOImplementation) GetTrafficData(
 
 	if cursor, err := trafficAnalysisCollection.Aggregate(ctx, query); err != nil {
 		logger.Error(fmt.Sprintf("Error retrieving traffic data for resource w/ name %s. Err: %v", resourceName, err))
-		return nil, &model.APIError{Message: "Could not get traffic data."}
+		return nil, &model.APIError{StatusCode: http.StatusInternalServerError, Message: "Could not get traffic data."}
 	} else {
 		td := []model.TrafficResourceUtilizationMetric{}
 		if err := cursor.All(ctx, &td); err != nil {
 			logger.Error(fmt.Sprintf("Error retrieving traffic data for resource w/ name %s. Err: %v", resourceName, err))
-			return nil, &model.APIError{Message: "Could not get traffic data."}
+			return nil, &model.APIError{StatusCode: http.StatusInternalServerError, Message: "Could not get traffic data."}
 		}
 
 		return td, nil
@@ -154,7 +154,7 @@ func (dbInterface SKCSuggestionEngineDAOImplementation) GetCardOfTheDay(ctx cont
 			return nil, nil
 		}
 		logger.Error(fmt.Sprintf("Error retrieving card of the day for given date: %s. Err: %s", date, err))
-		return nil, &model.APIError{Message: "Could not get card of the day."}
+		return nil, &model.APIError{StatusCode: http.StatusInternalServerError, Message: "Could not get card of the day."}
 	}
 
 	return &cotd.CardID, nil

--- a/db/skc_suggestion_engine_db.go
+++ b/db/skc_suggestion_engine_db.go
@@ -195,7 +195,7 @@ func (dbInterface SKCSuggestionEngineDAOImplementation) InsertCardOfTheDay(ctx c
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
-	logger.Info(fmt.Sprintf("Inserting new card of the day for date %s. Card being saved is %s. Using version %d.", cotd.Date, cotd.CardID, cotd.Version))
+	logger.Info(fmt.Sprintf("Inserting new COTD - ID: %s version %d", cotd.CardID, cotd.Version))
 
 	if _, err := cardOfTheDayCollection.InsertOne(ctx, cotd); err != nil {
 		logger.Error(fmt.Sprintf("Could not insert card of the day, err %s", err))

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.2
 require (
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
-	github.com/go-playground/validator/v10 v10.22.1
+	github.com/go-playground/validator/v10 v10.23.0
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.22.1 h1:40JcKH+bBNGFczGuoBYgX4I6m/i27HYW8P9FDk5PbgA=
 github.com/go-playground/validator/v10 v10.22.1/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/go-playground/validator/v10 v10.23.0 h1:/PwmTwZhS0dPkav3cdK9kV1FsAmrL8sThn8IHr/sO+o=
+github.com/go-playground/validator/v10 v10.23.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
-github.com/go-playground/validator/v10 v10.22.1 h1:40JcKH+bBNGFczGuoBYgX4I6m/i27HYW8P9FDk5PbgA=
-github.com/go-playground/validator/v10 v10.22.1/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/go-playground/validator/v10 v10.23.0 h1:/PwmTwZhS0dPkav3cdK9kV1FsAmrL8sThn8IHr/sO+o=
 github.com/go-playground/validator/v10 v10.23.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=

--- a/model/card_of_the_day.go
+++ b/model/card_of_the_day.go
@@ -2,7 +2,7 @@ package model
 
 type CardOfTheDay struct {
 	Date    string `bson:"date" json:"date"`
-	Version uint8  `bson:"version" json:"version"`
+	Version int    `bson:"version" json:"version"`
 	CardID  string `bson:"cardID" json:"-"`
 	Card    Card   `bson:"-" json:"card"`
 }

--- a/testing/skc_db_dao_mock.go
+++ b/testing/skc_db_dao_mock.go
@@ -97,8 +97,8 @@ func (imp SKCDatabaseAccessObjectMock) GetDesiredProductInDBUsingMultipleProduct
 	return model.BatchProductData[model.ProductIDs]{}, nil
 }
 
-func (imp SKCDatabaseAccessObjectMock) GetRandomCard(ctx context.Context) (string, *model.APIError) {
-	log.Fatalln("GetArchetypeExclusionsUsingCardText() not mocked")
+func (imp SKCDatabaseAccessObjectMock) GetRandomCard(ctx context.Context, blacklistedCards []string) (string, *model.APIError) {
+	log.Fatalln("GetRandomCard() not mocked")
 	return "", nil
 }
 

--- a/testing/skc_suggestion_engine_dao_mocks.go
+++ b/testing/skc_suggestion_engine_dao_mocks.go
@@ -30,7 +30,7 @@ func (dbInterface SKCSuggestionEngineDAOImplementation) IsBlackListed(ctx contex
 	return false, nil
 }
 
-func (dbInterface SKCSuggestionEngineDAOImplementation) GetCardOfTheDay(ctx context.Context, date string) (*string, *model.APIError) {
+func (dbInterface SKCSuggestionEngineDAOImplementation) GetCardOfTheDay(ctx context.Context, date string, version int) (*string, *model.APIError) {
 	log.Fatalln("GetCardOfTheDay() not mocked")
 	return nil, nil
 }

--- a/testing/skc_suggestion_engine_dao_mocks.go
+++ b/testing/skc_suggestion_engine_dao_mocks.go
@@ -35,6 +35,11 @@ func (dbInterface SKCSuggestionEngineDAOImplementation) GetCardOfTheDay(ctx cont
 	return nil, nil
 }
 
+func (dbInterface SKCSuggestionEngineDAOImplementation) GetHistoricalCardOfTheDayData(ctx context.Context, version int) ([]string, *model.APIError) {
+	log.Fatalln("GetHistoricalCardOfTheDayData() not mocked")
+	return nil, nil
+}
+
 func (dbInterface SKCSuggestionEngineDAOImplementation) InsertCardOfTheDay(ctx context.Context, cotd model.CardOfTheDay) *model.APIError {
 	log.Fatalln("InsertCardOfTheDay() not mocked")
 	return nil


### PR DESCRIPTION
## Changes
### COTD
* Fixed an issue in COTD logic where fetching a new card from DB might result in a card that was previously COTD. This would in turn result in error when trying to update the DB as no dupes are allowed
* As part of COTD fix, added new DB query to fetch a random card excluding blacklisted cards - in the context of COTD, a black listed card is just a card that was already COTD
* Also as part of COTD, added new query to get all previous COTD entries for a particular version
* Finally, updated existing methods to accept the COTD version for future changes

### Other
* Trending data is now analyzed using smaller frequencies to get more current results
* Code cleanup